### PR TITLE
DecomojiColors_v5 を npm から require() する方式に変える

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@decomoji/decomoji-colors": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@decomoji/decomoji-colors/-/decomoji-colors-1.1.0.tgz",
-      "integrity": "sha512-zCvTXIxlU0KbA6OMDrXuAeO7BEVfvCZJjtZxijN4+9/prGoujKFAmu6k+5TxGEceE2pR/UlIRUM6h/+Ve8hsnQ=="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@decomoji/decomoji-colors/-/decomoji-colors-1.2.0.tgz",
+      "integrity": "sha512-0XHpR5bGQgtlHiv1mW8tX3uP3SS9Nvc8i/qLBitYl27rMsOn1HdB+XapIWs+Zcg8H+3AAJnswwWSzbxssljaYQ=="
     },
     "minimist": {
       "version": "1.2.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,11 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@decomoji/decomoji-colors": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@decomoji/decomoji-colors/-/decomoji-colors-1.1.0.tgz",
+      "integrity": "sha512-zCvTXIxlU0KbA6OMDrXuAeO7BEVfvCZJjtZxijN4+9/prGoujKFAmu6k+5TxGEceE2pR/UlIRUM6h/+Ve8hsnQ=="
+    },
     "minimist": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "homepage": "https://github.com/decomoji/decomoji-colors-getter#readme",
   "dependencies": {
-    "@decomoji/decomoji-colors": "^1.1.0",
+    "@decomoji/decomoji-colors": "^1.2.0",
     "minimist": "^1.2.5",
     "mkdirp": "^1.0.3",
     "png-js": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "homepage": "https://github.com/decomoji/decomoji-colors-getter#readme",
   "dependencies": {
+    "@decomoji/decomoji-colors": "^1.1.0",
     "minimist": "^1.2.5",
     "mkdirp": "^1.0.3",
     "png-js": "^1.0.0"

--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,7 @@ const fs = require('fs')
 const argv = require('minimist')(process.argv.slice(2))
 const mkdirp = require('mkdirp')
 const PNG = require('png-js')
-const DecomojiColorsHEX = require('@decomoji/decomoji-colors')
+const DecomojiColorsHEX = require('@decomoji/decomoji-colors').DecomojiColorsHEX
 
 const inputDir = argv['input-dir'] || '.'
 const output = argv.output || './dist/result.tsv'

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@ const fs = require('fs')
 const argv = require('minimist')(process.argv.slice(2))
 const mkdirp = require('mkdirp')
 const PNG = require('png-js')
+const DecomojiColorsHEX = require('@decomoji/decomoji-colors')
 
 const inputDir = argv['input-dir'] || '.'
 const output = argv.output || './dist/result.tsv'
@@ -26,26 +27,11 @@ Promise.all(promises).then(colors => {
   )
 })
 
-const DecomojiColors_v5 = [
-  'dd3b40', // 0
-  'c05b2c', // 1
-  '9f7e00', // 2
-  '688200', // 3
-  '008c22', // 4
-  '008780', // 5
-  '0081b1', // 6
-  '477f9b', // 7
-  '5d79aa', // 8
-  'a156d2', // 9
-  'd43892', // 10
-  'a36969' // 11
-]
-
 function colorIndex({ r, g, b }) {
   const rr = r.toString(16).padStart(2, '0')
   const gg = g.toString(16).padStart(2, '0')
   const bb = b.toString(16).padStart(2, '0')
-  return DecomojiColors_v5.indexOf(`${rr}${gg}${bb}`)
+  return DecomojiColorsHEX.indexOf(`${rr}${gg}${bb}`)
 }
 
 function readColor(file) {


### PR DESCRIPTION
decomoji-colors を npm publish したので、これを利用します。

https://www.npmjs.com/package/@decomoji/decomoji-colors